### PR TITLE
Add MQTT connection event support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Configure your devices to communicate with the backend using the following MQTT 
 
 | Topic                                                    | Purpose                                       | Example Topic                                    |
 | -------------------------------------------------------- | --------------------------------------------- | ------------------------------------------------ |
-| `smartreader/{deviceSerial}/events`                      | Publish tag read and status events to the backend          | `smartreader/ABC123/events`                      |
+| `smartreader/{deviceSerial}/events`                      | Publish tag read, status, and connection events to the backend          | `smartreader/ABC123/events`           |
 | `smartreader/{deviceSerial}/command/control`             | Receive control commands from the backend     | `smartreader/ABC123/command/control`             |
 | `smartreader/{deviceSerial}/command/control/response`    | Publish command responses back to the backend | `smartreader/ABC123/command/control/response`    |
 | `smartreader/{deviceSerial}/command/management`          | Receive management commands from the backend  | `smartreader/ABC123/command/management`          |

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/smartreader-frontend/'],
+};

--- a/src/mqtt/mqtt.service.ts
+++ b/src/mqtt/mqtt.service.ts
@@ -121,6 +121,15 @@ export class MqttService implements OnModuleInit {
         payload: { ...payload, deviceSerial },
       };
       this.eventBuffer.push(event);
+    } else if (payload['smartreader-mqtt-status']) {
+      const deviceSerial = payload.deviceSerial || payload.readerName;
+      const event = {
+        eventType: 'mqttConnection',
+        deviceSerial,
+        timestamp: new Date(),
+        payload: { ...payload, deviceSerial },
+      };
+      this.eventBuffer.push(event);
     } else if (Array.isArray(payload)) {
       payload.forEach((event: any) => this.eventBuffer.push(event));
     } else {


### PR DESCRIPTION
## Summary
- handle MQTT connection events in mqtt service
- document connection events in README
- add jest config to ignore frontend tests

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6887d6d9ec908323a8f8598a9d2f0c1a