### PR TITLE
Add inventory status event support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Configure your devices to communicate with the backend using the following MQTT 
 
 | Topic                                                    | Purpose                                       | Example Topic                                    |
 | -------------------------------------------------------- | --------------------------------------------- | ------------------------------------------------ |
-| `smartreader/{deviceSerial}/events`                      | Publish tag read, status, and connection events to the backend          | `smartreader/ABC123/events`           |
+| `smartreader/{deviceSerial}/events`                      | Publish tag read, status, inventory status, and connection events to the backend          | `smartreader/ABC123/events`           |
 | `smartreader/{deviceSerial}/command/control`             | Receive control commands from the backend     | `smartreader/ABC123/command/control`             |
 | `smartreader/{deviceSerial}/command/control/response`    | Publish command responses back to the backend | `smartreader/ABC123/command/control/response`    |
 | `smartreader/{deviceSerial}/command/management`          | Receive management commands from the backend  | `smartreader/ABC123/command/management`          |

--- a/src/mqtt/mqtt.service.ts
+++ b/src/mqtt/mqtt.service.ts
@@ -130,6 +130,18 @@ export class MqttService implements OnModuleInit {
         payload: { ...payload, deviceSerial },
       };
       this.eventBuffer.push(event);
+    } else if (
+      typeof payload.status === 'string' &&
+      ['running', 'idle', 'iddle'].includes(payload.status.toLowerCase())
+    ) {
+      const deviceSerial = payload.deviceSerial || payload.readerName;
+      const event = {
+        eventType: 'inventoryStatus',
+        deviceSerial,
+        timestamp: new Date(),
+        payload: { ...payload, deviceSerial },
+      };
+      this.eventBuffer.push(event);
     } else if (Array.isArray(payload)) {
       payload.forEach((event: any) => this.eventBuffer.push(event));
     } else {


### PR DESCRIPTION
## Summary
- handle new inventory status events in `MqttService`
- mention inventory status events in MQTT topic table

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6887d8ce869c8323a4fac1941914530d