### PR TITLE
Add GPI status event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Configure your devices to communicate with the backend using the following MQTT 
 
 | Topic                                                    | Purpose                                       | Example Topic                                    |
 | -------------------------------------------------------- | --------------------------------------------- | ------------------------------------------------ |
-| `smartreader/{deviceSerial}/events`                      | Publish tag read, status, inventory status, heartbeat, and connection events to the backend          | `smartreader/ABC123/events`           |
+| `smartreader/{deviceSerial}/events`                      | Publish tag read, status, inventory status, heartbeat, GPI status, and connection events to the backend          | `smartreader/ABC123/events`           |
 | `smartreader/{deviceSerial}/command/control`             | Receive control commands from the backend     | `smartreader/ABC123/command/control`             |
 | `smartreader/{deviceSerial}/command/control/response`    | Publish command responses back to the backend | `smartreader/ABC123/command/control/response`    |
 | `smartreader/{deviceSerial}/command/management`          | Receive management commands from the backend  | `smartreader/ABC123/command/management`          |

--- a/src/mqtt/mqtt.service.ts
+++ b/src/mqtt/mqtt.service.ts
@@ -145,6 +145,23 @@ export class MqttService implements OnModuleInit {
         payload: { ...payload, deviceSerial },
       };
       this.eventBuffer.push(event);
+    } else if (payload.eventType === 'gpi-status') {
+      const deviceSerial =
+        payload.deviceSerial || payload.readerName || payload.mac || 'unknown';
+      const event = {
+        eventType: 'gpi-status',
+        deviceSerial,
+        timestamp: payload.timestamp
+          ? new Date(Math.floor(payload.timestamp / 1000))
+          : new Date(),
+        payload: {
+          gpiConfigurations: payload.gpiConfigurations,
+          readerName: payload.readerName,
+          mac: payload.mac,
+          deviceSerial,
+        },
+      };
+      this.eventBuffer.push(event);
     } else if (Array.isArray(payload)) {
       payload.forEach((event: any) => this.eventBuffer.push(event));
     } else {


### PR DESCRIPTION
## Summary
- handle `gpi-status` events in MQTT service
- document GPI events in README

## Testing
- `pnpm install --ignore-scripts`
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e5f586408323b5f8b30213063836